### PR TITLE
Use `call()` to correctly assign `this` in handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var matches = require('matches-selector')
 
 exports.bind = function(el, selector, type, fn, capture){
   return event.bind(el, type, function(e){
-    if (matches(e.target, selector)) fn(e);
+    if (matches(e.target, selector)) fn.call(el, e);
   }, capture);
 };
 


### PR DESCRIPTION
The handler function's `this` should refer to the element to which the
listener is bound, rather than the `window` object. This also ensures
that `this` is equal to `e.currentTarget` within the handler function.

Fixes #5
